### PR TITLE
[FEATURE] add support for custom field of type 'price'

### DIFF
--- a/Product/CustomFieldUpdater.php
+++ b/Product/CustomFieldUpdater.php
@@ -105,6 +105,11 @@ class CustomFieldUpdater implements EventSubscriberInterface
                 return [
                     'type' => 'text',
                 ];
+            case CustomFieldTypes::PRICE:
+                return [
+                    'type' => 'object',
+                    'dynamic' => true,
+                ];
             case CustomFieldTypes::COLORPICKER:
             case CustomFieldTypes::ENTITY:
             case CustomFieldTypes::MEDIA:


### PR DESCRIPTION
### **1. Why is this change necessary?**

For elasticsearch to handle parsing of customfield of type price where the default type "keyword" is set.

### **2. What does this change do, exactly?**

defines elasticsearch type for customfield “price”

### **3. Describe each step to reproduce the issue or behaviour.**

- create a customfield of type `Shopware\Core\System\CustomField\CustomFieldTypes::PRICE`
- add some value for this custom field for some product
- run `bin/console es:reset` to reset ES indices (can be skipped)
- try `bin/console es:index --no-queue` . 
- Expect to see error message that says 
```
failed to parse field [customFields.my_custom_field] of type [keyword] in document with id [product-uuid]. Preview of field's value: '{gross=125.0, currencyId=b7d2554b0ce847cd82f3ac9bd1c0dfca, net=100.0, linked=false}' 
```
 because ES type mapping tries to parse the price customfield with the default case where 'type' => "keyword" is set and thus fails.

### **4. Please link to the relevant issues (if any).**

### **5. Checklist**

- [x]  I have rebased my changes to remove merge conflicts
- [ ]  I have written tests and verified that they fail without my change
- [ ]  I have created a [[changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md)](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ]  I have written or adjusted the documentation according to my changes
- [x]  This change has comments for package types, values, functions, and non-obvious lines of code
- [x]  I have read the contribution requirements and fulfil them.